### PR TITLE
feat: 정산 도메인 구현

### DIFF
--- a/Backend/build.gradle
+++ b/Backend/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempExpense.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempExpense.java
@@ -1,9 +1,25 @@
 package com.luckyseven.backend.domain.settlements;
 
 import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TempExpense extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
+  private TempTeam team;
 
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempExpense.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempExpense.java
@@ -1,0 +1,9 @@
+package com.luckyseven.backend.domain.settlements;
+
+import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class TempExpense extends BaseEntity {
+
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempMember.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempMember.java
@@ -1,8 +1,24 @@
 package com.luckyseven.backend.domain.settlements;
 
 import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TempMember extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
+  private TempTeam team;
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempMember.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempMember.java
@@ -1,0 +1,8 @@
+package com.luckyseven.backend.domain.settlements;
+
+import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class TempMember extends BaseEntity {
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempTeam.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/TempTeam.java
@@ -1,0 +1,9 @@
+package com.luckyseven.backend.domain.settlements;
+
+import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class TempTeam extends BaseEntity {
+
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
@@ -1,0 +1,23 @@
+package com.luckyseven.backend.domain.settlements.api;
+
+import com.luckyseven.backend.domain.settlements.app.SettlementService;
+import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SettlementController {
+
+  private final SettlementService settlementService;
+
+  @GetMapping("/{settlementId}")
+  public ResponseEntity<SettlementResponse> readSettlement(@PathVariable Long settlementId) {
+    return ResponseEntity.ok(settlementService.readSettlement(settlementId));
+  }
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
@@ -2,16 +2,20 @@ package com.luckyseven.backend.domain.settlements.api;
 
 import com.luckyseven.backend.domain.settlements.app.SettlementService;
 import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import com.luckyseven.backend.domain.settlements.dto.SettlementSearchCondition;
 import com.luckyseven.backend.domain.settlements.dto.SettlementUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,14 +45,11 @@ public class SettlementController {
   @GetMapping("/teams/{teamId}/settlements")
   public ResponseEntity<Page<SettlementResponse>> readSettlements(
       @PathVariable Long teamId,
-      @RequestParam(required = false) Long expenseId,
-      @RequestParam(required = false) Long payerId,
-      @RequestParam(required = false) Long settlerId,
-      @RequestParam(required = false) Boolean isSettled,
-      @RequestParam(defaultValue = "0") Integer page,
-      @RequestParam(defaultValue = "10") Integer size) {
-    Page<SettlementResponse> settlementPage = settlementService.readSettlementPage(teamId, payerId,
-        settlerId, expenseId, isSettled, PageRequest.of(page, size));
+      @ModelAttribute SettlementSearchCondition condition,
+      @PageableDefault(page = 0, size = 10) Pageable pageable
+  ) {
+    Page<SettlementResponse> settlementPage = settlementService.readSettlementPage(teamId,
+        condition, pageable);
     return ResponseEntity.ok(settlementPage);
   }
 
@@ -59,7 +60,7 @@ public class SettlementController {
   public ResponseEntity<SettlementResponse> updateSettlement(
       @PathVariable Long settlementId,
       @Parameter(description = "true면 body를 무시하고 정산처리만 진행") @RequestParam(defaultValue = "false") Boolean settledOnly
-      , @RequestBody SettlementUpdateRequest request) {
+      , @Valid @RequestBody SettlementUpdateRequest request) {
     if (settledOnly) {
       return ResponseEntity.ok(settlementService.settleSettlement(settlementId));
     } else {

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
@@ -2,11 +2,17 @@ package com.luckyseven.backend.domain.settlements.api;
 
 import com.luckyseven.backend.domain.settlements.app.SettlementService;
 import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import com.luckyseven.backend.domain.settlements.dto.SettlementUpdateRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,8 +22,33 @@ public class SettlementController {
 
   private final SettlementService settlementService;
 
-  @GetMapping("/{settlementId}")
+  @GetMapping("/settlements/{settlementId}")
   public ResponseEntity<SettlementResponse> readSettlement(@PathVariable Long settlementId) {
     return ResponseEntity.ok(settlementService.readSettlement(settlementId));
+  }
+
+  @GetMapping("/teams/{teamId}/settlements")
+  public ResponseEntity<Page<SettlementResponse>> readSettlements(
+      @PathVariable Long teamId,
+      @RequestParam(required = false) Long expenseId,
+      @RequestParam(required = false) Long payerId,
+      @RequestParam(required = false) Long settlerId,
+      @RequestParam(required = false) Boolean isSettled,
+      @RequestParam(defaultValue = "0") Integer page,
+      @RequestParam(defaultValue = "10") Integer size) {
+    Page<SettlementResponse> settlementPage = settlementService.readSettlementPage(teamId, payerId,
+        settlerId, expenseId, isSettled, PageRequest.of(page, size));
+    return ResponseEntity.ok(settlementPage);
+  }
+
+  @PatchMapping("/settlements/{settlementId}")
+  public ResponseEntity<SettlementResponse> updateSettlement(@PathVariable Long settlementId,
+      @RequestParam(defaultValue = "false") Boolean settledOnly
+      , @RequestBody SettlementUpdateRequest request) {
+    if (settledOnly) {
+      return ResponseEntity.ok(settlementService.settleSettlement(settlementId));
+    } else {
+      return ResponseEntity.ok(settlementService.updateSettlement(settlementId, request));
+    }
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
@@ -10,12 +10,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,7 +45,7 @@ public class SettlementController {
   @GetMapping("/teams/{teamId}/settlements")
   public ResponseEntity<Page<SettlementResponse>> readSettlements(
       @PathVariable Long teamId,
-      @ModelAttribute SettlementSearchCondition condition,
+      @ParameterObject SettlementSearchCondition condition,
       @PageableDefault(page = 0, size = 10) Pageable pageable
   ) {
     Page<SettlementResponse> settlementPage = settlementService.readSettlementPage(teamId,

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/api/SettlementController.java
@@ -3,6 +3,10 @@ package com.luckyseven.backend.domain.settlements.api;
 import com.luckyseven.backend.domain.settlements.app.SettlementService;
 import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
 import com.luckyseven.backend.domain.settlements.dto.SettlementUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,15 +22,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Tag(name = "Settlement")
 public class SettlementController {
 
   private final SettlementService settlementService;
 
+  @Operation(summary = "ID로 정산 조회")
+  @ApiResponse(responseCode = "200", description = "Settlement found")
+  @ApiResponse(responseCode = "404", description = "Settlement not found")
   @GetMapping("/settlements/{settlementId}")
   public ResponseEntity<SettlementResponse> readSettlement(@PathVariable Long settlementId) {
     return ResponseEntity.ok(settlementService.readSettlement(settlementId));
   }
 
+  @Operation(summary = "팀ID로 정산 목록 조회, 필터조건 추가 가능")
+  @ApiResponse(responseCode = "200", description = "Successfully retrieved settlements")
+  @ApiResponse(responseCode = "400", description = "TeamID가 null인경우")
   @GetMapping("/teams/{teamId}/settlements")
   public ResponseEntity<Page<SettlementResponse>> readSettlements(
       @PathVariable Long teamId,
@@ -41,9 +52,13 @@ public class SettlementController {
     return ResponseEntity.ok(settlementPage);
   }
 
+  @Operation(summary = "Update settlement")
+  @ApiResponse(responseCode = "200", description = "Settlement updated successfully")
+  @ApiResponse(responseCode = "404", description = "Settlement not found")
   @PatchMapping("/settlements/{settlementId}")
-  public ResponseEntity<SettlementResponse> updateSettlement(@PathVariable Long settlementId,
-      @RequestParam(defaultValue = "false") Boolean settledOnly
+  public ResponseEntity<SettlementResponse> updateSettlement(
+      @PathVariable Long settlementId,
+      @Parameter(description = "true면 body를 무시하고 정산처리만 진행") @RequestParam(defaultValue = "false") Boolean settledOnly
       , @RequestBody SettlementUpdateRequest request) {
     if (settledOnly) {
       return ResponseEntity.ok(settlementService.settleSettlement(settlementId));

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
@@ -2,6 +2,7 @@ package com.luckyseven.backend.domain.settlements.app;
 
 import com.luckyseven.backend.domain.settlements.TempExpense;
 import com.luckyseven.backend.domain.settlements.TempMember;
+import com.luckyseven.backend.domain.settlements.TempTeam;
 import com.luckyseven.backend.domain.settlements.dao.SettlementRepository;
 import com.luckyseven.backend.domain.settlements.dao.SettlementSpecification;
 import com.luckyseven.backend.domain.settlements.dto.SettlementCreateRequest;
@@ -28,9 +29,10 @@ public class SettlementService {
   @Transactional
   public SettlementResponse createSettlement(SettlementCreateRequest request) {
     // TODO: TEMP 엔티티 제거
-    TempMember settler = new TempMember();
-    TempMember payer = new TempMember();
-    TempExpense expense = new TempExpense();
+    TempTeam team = new TempTeam();
+    TempMember settler = new TempMember(team);
+    TempMember payer = new TempMember(team);
+    TempExpense expense = new TempExpense(team);
     Settlement settlement = SettlementMapper.fromSettlementCreateRequest(request, settler, payer,
         expense);
     return SettlementMapper.toSettlementResponse(settlementRepository.save(settlement));
@@ -56,7 +58,7 @@ public class SettlementService {
         .and(SettlementSpecification.hasPayerId(condition.getPayerId()))
         .and(SettlementSpecification.hasSettlerId(condition.getSettlerId()))
         .and(SettlementSpecification.hasExpenseId(condition.getExpenseId()))
-        .and(SettlementSpecification.hasIsSettled(condition.getIsSettled()));
+        .and(SettlementSpecification.isSettled(condition.getIsSettled()));
     Page<Settlement> settlementPage = settlementRepository.findAll(specification, pageable);
 
     return settlementPage.map(SettlementMapper::toSettlementResponse);
@@ -67,7 +69,7 @@ public class SettlementService {
     Settlement settlement = settlementRepository.findById(id).orElseThrow(
         () -> new CustomLogicException(ExceptionCode.SETTLEMENT_NOT_FOUND)
     );
-    // TODO: null 실제 엔티티로 대체
+    // TODO: 실제 엔티티로 대체
     settlement.update(request.getAmount(), null, null, null, request.getIsSettled());
     return SettlementMapper.toSettlementResponse(settlementRepository.save(settlement));
   }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
@@ -1,0 +1,31 @@
+package com.luckyseven.backend.domain.settlements.app;
+
+import com.luckyseven.backend.domain.settlements.dao.SettlementRepository;
+import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import com.luckyseven.backend.domain.settlements.util.SettlementMapper;
+import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
+import com.luckyseven.backend.sharedkernel.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementService {
+
+  private final SettlementRepository settlementRepository;
+
+  @Transactional
+  public void createSettlement() {
+
+  }
+
+  @Transactional(readOnly = true)
+  public SettlementResponse readSettlement(Long id) {
+    Settlement settlement = settlementRepository.findById(id).orElseThrow(
+        () -> new CustomLogicException(ExceptionCode.SETTLEMENT_NOT_FOUND)
+    );
+    return SettlementMapper.toSettlementResponse(settlement);
+  }
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
@@ -6,6 +6,7 @@ import com.luckyseven.backend.domain.settlements.dao.SettlementRepository;
 import com.luckyseven.backend.domain.settlements.dao.SettlementSpecification;
 import com.luckyseven.backend.domain.settlements.dto.SettlementCreateRequest;
 import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import com.luckyseven.backend.domain.settlements.dto.SettlementSearchCondition;
 import com.luckyseven.backend.domain.settlements.dto.SettlementUpdateRequest;
 import com.luckyseven.backend.domain.settlements.entity.Settlement;
 import com.luckyseven.backend.domain.settlements.util.SettlementMapper;
@@ -44,18 +45,18 @@ public class SettlementService {
   }
 
   @Transactional(readOnly = true)
-  public Page<SettlementResponse> readSettlementPage(Long teamId, Long payerId, Long settlerId,
-      Long expenseId, Boolean isSettled, Pageable pageable) {
+  public Page<SettlementResponse> readSettlementPage(Long teamId,
+      SettlementSearchCondition condition, Pageable pageable) {
     if (teamId == null) {
       throw new CustomLogicException(ExceptionCode.BAD_REQUEST);
     }
 
     Specification<Settlement> specification = Specification
         .where(SettlementSpecification.hasTeamId(teamId))
-        .and(SettlementSpecification.hasPayerId(payerId))
-        .and(SettlementSpecification.hasSettlerId(settlerId))
-        .and(SettlementSpecification.hasExpenseId(expenseId))
-        .and(SettlementSpecification.hasIsSettled(isSettled));
+        .and(SettlementSpecification.hasPayerId(condition.getPayerId()))
+        .and(SettlementSpecification.hasSettlerId(condition.getSettlerId()))
+        .and(SettlementSpecification.hasExpenseId(condition.getExpenseId()))
+        .and(SettlementSpecification.hasIsSettled(condition.getIsSettled()));
     Page<Settlement> settlementPage = settlementRepository.findAll(specification, pageable);
 
     return settlementPage.map(SettlementMapper::toSettlementResponse);

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
@@ -13,6 +13,7 @@ import com.luckyseven.backend.domain.settlements.entity.Settlement;
 import com.luckyseven.backend.domain.settlements.util.SettlementMapper;
 import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
 import com.luckyseven.backend.sharedkernel.exception.ExceptionCode;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,12 +36,13 @@ public class SettlementService {
     TempExpense expense = new TempExpense(team);
     Settlement settlement = SettlementMapper.fromSettlementCreateRequest(request, settler, payer,
         expense);
+    BigDecimal amount = request.getAmount();
     return SettlementMapper.toSettlementResponse(settlementRepository.save(settlement));
   }
 
   @Transactional(readOnly = true)
   public SettlementResponse readSettlement(Long id) {
-    Settlement settlement = settlementRepository.findById(id).orElseThrow(
+    Settlement settlement = settlementRepository.findWithSettlerAndPayerById(id).orElseThrow(
         () -> new CustomLogicException(ExceptionCode.SETTLEMENT_NOT_FOUND)
     );
     return SettlementMapper.toSettlementResponse(settlement);

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
@@ -46,6 +46,16 @@ public class SettlementService {
     return SettlementMapper.toSettlementResponse(settlement);
   }
 
+
+  /**
+   * 검색 조건에 따른 정산 목록을 페이지네이션하여 조회합니다. teamId는 필수 condition 각 속성은 선택
+   *
+   * @param teamId    팀 ID (필터링 조건)
+   * @param condition 지불자 ID, 정산자 ID, 지출 ID, 정산 상태를 포함하는 검색 조건
+   * @param pageable  페이지네이션 정보
+   * @return 검색 조건에 맞는 정산 응답 객체들이 담긴 Page 객체
+   * @throws CustomLogicException teamId가 null인 경우 (BAD_REQUEST)
+   */
   @Transactional(readOnly = true)
   public Page<SettlementResponse> readSettlementPage(Long teamId,
       SettlementSearchCondition condition, Pageable pageable) {

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepository.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepository.java
@@ -2,9 +2,12 @@ package com.luckyseven.backend.domain.settlements.dao;
 
 import com.luckyseven.backend.domain.settlements.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+public interface SettlementRepository extends JpaRepository<Settlement, Long>,
+    JpaSpecificationExecutor<Settlement> {
+
 
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepository.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepository.java
@@ -1,0 +1,10 @@
+package com.luckyseven.backend.domain.settlements.dao;
+
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepository.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepository.java
@@ -1,6 +1,8 @@
 package com.luckyseven.backend.domain.settlements.dao;
 
 import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -9,5 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface SettlementRepository extends JpaRepository<Settlement, Long>,
     JpaSpecificationExecutor<Settlement> {
 
+  @EntityGraph(attributePaths = {"settler", "payer"})
+  Optional<Settlement> findWithSettlerAndPayerById(Long id);
 
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementSpecification.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementSpecification.java
@@ -1,0 +1,32 @@
+package com.luckyseven.backend.domain.settlements.dao;
+
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import org.springframework.data.jpa.domain.Specification;
+
+public class SettlementSpecification {
+
+  public static Specification<Settlement> hasTeamId(Long teamId) {
+    return (root, query, cb) -> teamId == null ? null :
+        cb.equal(root.get("expense").get("team").get("id"), teamId);
+  }
+
+  public static Specification<Settlement> hasPayerId(Long payerId) {
+    return (root, query, criteriaBuilder) -> payerId == null ? null
+        : criteriaBuilder.equal(root.get("payer").get("id"), payerId);
+  }
+
+  public static Specification<Settlement> hasSettlerId(Long settlerId) {
+    return (root, query, criteriaBuilder) -> settlerId == null ? null
+        : criteriaBuilder.equal(root.get("settler").get("id"), settlerId);
+  }
+
+  public static Specification<Settlement> hasExpenseId(Long expenseId) {
+    return (root, query, criteriaBuilder) -> expenseId == null ? null
+        : criteriaBuilder.equal(root.get("expense").get("id"), expenseId);
+  }
+
+  public static Specification<Settlement> hasIsSettled(Boolean isSettled) {
+    return (root, query, criteriaBuilder) -> isSettled == null ? null
+        : criteriaBuilder.equal(root.get("expense").get("id"), isSettled);
+  }
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementSpecification.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dao/SettlementSpecification.java
@@ -25,8 +25,8 @@ public class SettlementSpecification {
         : criteriaBuilder.equal(root.get("expense").get("id"), expenseId);
   }
 
-  public static Specification<Settlement> hasIsSettled(Boolean isSettled) {
+  public static Specification<Settlement> isSettled(Boolean isSettled) {
     return (root, query, criteriaBuilder) -> isSettled == null ? null
-        : criteriaBuilder.equal(root.get("expense").get("id"), isSettled);
+        : criteriaBuilder.equal(root.get("isSettled"), isSettled);
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementCreateRequest.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementCreateRequest.java
@@ -1,0 +1,29 @@
+package com.luckyseven.backend.domain.settlements.dto;
+
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Data;
+
+/**
+ * DTO for {@link Settlement}
+ */
+@Data
+public class SettlementCreateRequest {
+
+  @NotNull
+  @DecimalMin(value = "0.0", inclusive = false)
+  @Digits(integer = 15, fraction = 2)
+  private BigDecimal amount;
+
+  @NotNull
+  private Long settlerId;
+
+  @NotNull
+  private Long payerId;
+
+  @NotNull
+  private Long expenseId;
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementResponse.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementResponse.java
@@ -1,0 +1,24 @@
+package com.luckyseven.backend.domain.settlements.dto;
+
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * DTO for {@link Settlement}
+ */
+@Data
+@Builder
+public class SettlementResponse {
+
+  private Long id;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private BigDecimal amount;
+  private Boolean isSettled;
+  private Long settlerId;
+  private Long payerId;
+  private Long expenseId;
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementSearchCondition.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementSearchCondition.java
@@ -1,0 +1,13 @@
+package com.luckyseven.backend.domain.settlements.dto;
+
+import lombok.Data;
+
+@Data
+public class SettlementSearchCondition {
+
+  private Long expenseId;
+  private Long settlerId;
+  private Long payerId;
+  private Boolean isSettled;
+
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementUpdateRequest.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/dto/SettlementUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.luckyseven.backend.domain.settlements.dto;
+
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import java.math.BigDecimal;
+import lombok.Data;
+
+/**
+ * DTO for {@link Settlement}
+ */
+@Data
+public class SettlementUpdateRequest {
+
+  @DecimalMin(value = "0.0", inclusive = false)
+  @Digits(integer = 15, fraction = 2)
+  private BigDecimal amount;
+
+  private Boolean isSettled;
+
+  private Long settlerId;
+
+  private Long payerId;
+
+  private Long expenseId;
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/entity/Settlement.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/entity/Settlement.java
@@ -1,0 +1,47 @@
+package com.luckyseven.backend.domain.settlements.entity;
+
+import com.luckyseven.backend.domain.settlements.TempExpense;
+import com.luckyseven.backend.domain.settlements.TempMember;
+import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    indexes = {
+        @Index(name = "idx_settler", columnList = "settler_id"),  // settler에 대한 인덱스
+        @Index(name = "idx_payer", columnList = "payer_id"),      // payer에 대한 인덱스
+        @Index(name = "idx_expense", columnList = "expense_id")   // expense에 대한 인덱스
+    }
+)
+public class Settlement extends BaseEntity {
+
+  @Column(nullable = false, precision = 15, scale = 2)
+  private BigDecimal amount;
+  @Column(nullable = false)
+  private Boolean isSettled = false;
+
+  @ManyToOne
+  @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
+  private TempMember settler;
+
+  @ManyToOne
+  @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
+  private TempMember payer;
+
+  @ManyToOne
+  @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
+  private TempExpense expense;
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/entity/Settlement.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/entity/Settlement.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +34,7 @@ public class Settlement extends BaseEntity {
   @Column(nullable = false)
   private Boolean isSettled = false;
 
+  // TODO: TEMP 엔티티 제거
   @ManyToOne
   @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
   private TempMember settler;
@@ -44,4 +46,35 @@ public class Settlement extends BaseEntity {
   @ManyToOne
   @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
   private TempExpense expense;
+
+  @Builder
+  public Settlement(BigDecimal amount, TempMember settler, TempMember payer, TempExpense expense) {
+    this.amount = amount;
+    this.settler = settler;
+    this.payer = payer;
+    this.expense = expense;
+  }
+
+  public void update(BigDecimal amount, TempMember settler, TempMember payer, TempExpense expense,
+      Boolean isSettled) {
+    if (amount != null) {
+      this.amount = amount;
+    }
+    if (settler != null) {
+      this.settler = settler;
+    }
+    if (payer != null) {
+      this.payer = payer;
+    }
+    if (expense != null) {
+      this.expense = expense;
+    }
+    if (isSettled != null) {
+      this.isSettled = isSettled;
+    }
+  }
+
+  public void setSettled() {
+    this.isSettled = true;
+  }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/entity/Settlement.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/entity/Settlement.java
@@ -6,6 +6,7 @@ import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
@@ -35,15 +36,15 @@ public class Settlement extends BaseEntity {
   private Boolean isSettled = false;
 
   // TODO: TEMP 엔티티 제거
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
   private TempMember settler;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
   private TempMember payer;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
   private TempExpense expense;
 

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/util/SettlementMapper.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/util/SettlementMapper.java
@@ -1,5 +1,8 @@
 package com.luckyseven.backend.domain.settlements.util;
 
+import com.luckyseven.backend.domain.settlements.TempExpense;
+import com.luckyseven.backend.domain.settlements.TempMember;
+import com.luckyseven.backend.domain.settlements.dto.SettlementCreateRequest;
 import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
 import com.luckyseven.backend.domain.settlements.entity.Settlement;
 
@@ -19,5 +22,11 @@ public class SettlementMapper {
         .payerId(settlement.getPayer().getId())
         .expenseId(settlement.getExpense().getId())
         .build();
+  }
+
+  // TODO: TEMP 엔티티 제거
+  public static Settlement fromSettlementCreateRequest(SettlementCreateRequest request,
+      TempMember settler, TempMember payer, TempExpense expense) {
+    return new Settlement(request.getAmount(), settler, payer, expense);
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/util/SettlementMapper.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/util/SettlementMapper.java
@@ -1,0 +1,23 @@
+package com.luckyseven.backend.domain.settlements.util;
+
+import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+
+public class SettlementMapper {
+
+  private SettlementMapper() {
+  }
+
+  public static SettlementResponse toSettlementResponse(Settlement settlement) {
+    return SettlementResponse.builder()
+        .id(settlement.getId())
+        .amount(settlement.getAmount())
+        .createdAt(settlement.getCreatedAt())
+        .updatedAt(settlement.getUpdatedAt())
+        .isSettled(settlement.getIsSettled())
+        .settlerId(settlement.getSettler().getId())
+        .payerId(settlement.getPayer().getId())
+        .expenseId(settlement.getExpense().getId())
+        .build();
+  }
+}

--- a/Backend/src/main/java/com/luckyseven/backend/sharedkernel/entity/BaseEntity.java
+++ b/Backend/src/main/java/com/luckyseven/backend/sharedkernel/entity/BaseEntity.java
@@ -1,9 +1,13 @@
 package com.luckyseven.backend.sharedkernel.entity;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,6 +19,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
 
   @CreatedDate
   @Column(updatable = false, nullable = false)

--- a/Backend/src/main/java/com/luckyseven/backend/sharedkernel/exception/ExceptionCode.java
+++ b/Backend/src/main/java/com/luckyseven/backend/sharedkernel/exception/ExceptionCode.java
@@ -20,6 +20,7 @@ public enum ExceptionCode {
    * 404 NOT_FOUND: 리소스를 찾을 수 없음
    */
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+  SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "정산내역을 찾을 수 없습니다."),
 
   /*
    * 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출

--- a/Backend/src/main/resources/application-test.yml
+++ b/Backend/src/main/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true

--- a/Backend/src/test/java/com/luckyseven/backend/domain/settlements/api/SettlementControllerTest.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/settlements/api/SettlementControllerTest.java
@@ -1,0 +1,248 @@
+package com.luckyseven.backend.domain.settlements.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.luckyseven.backend.domain.settlements.app.SettlementService;
+import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import com.luckyseven.backend.domain.settlements.dto.SettlementSearchCondition;
+import com.luckyseven.backend.domain.settlements.dto.SettlementUpdateRequest;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(SettlementController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SettlementControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private SettlementService settlementService;
+
+  @MockitoBean
+  private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+
+  @Test
+  @DisplayName("ID로 정산 조회 API 테스트")
+  void readSettlement_ShouldReturnSettlement() throws Exception {
+    // given
+    Long settlementId = 1L;
+    SettlementResponse mockResponse = SettlementResponse.builder()
+        .id(settlementId)
+        .settlerId(10L)
+        .payerId(20L)
+        .expenseId(30L)
+        .build();
+
+    when(settlementService.readSettlement(settlementId)).thenReturn(mockResponse);
+
+    // when
+    MvcResult result = mockMvc.perform(get("/api/settlements/{settlementId}", settlementId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(settlementId))
+        .andReturn();
+
+    // then
+
+    verify(settlementService, times(1)).readSettlement(settlementId);
+  }
+
+  @Test
+  @DisplayName("팀ID로 정산 목록 조회 API 테스트")
+  void readSettlements_ShouldReturnSettlementPage() throws Exception {
+    // given
+    Long teamId = 1L;
+    SettlementResponse settlement1 = SettlementResponse.builder()
+        .id(1L)
+        .amount(BigDecimal.valueOf(1000))
+        .settlerId(10L)
+        .payerId(20L)
+        .expenseId(30L)
+        .build();
+
+    SettlementResponse settlement2 = SettlementResponse.builder()
+        .id(2L)
+        .amount(BigDecimal.valueOf(2000))
+        .settlerId(11L)
+        .payerId(21L)
+        .expenseId(31L)
+        .isSettled(true)
+        .build();
+
+    List<SettlementResponse> settlements = List.of(settlement1, settlement2);
+    Page<SettlementResponse> mockPage = new PageImpl<>(settlements, PageRequest.of(0, 10), 2);
+
+    when(settlementService.readSettlementPage(eq(teamId), any(SettlementSearchCondition.class),
+        any(Pageable.class)))
+        .thenReturn(mockPage);
+
+    // when
+    MvcResult result = mockMvc.perform(get("/api/teams/{teamId}/settlements", teamId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").value(settlement1.getId()))
+        .andExpect(jsonPath("$.content[1].id").value(settlement2.getId()))
+        .andReturn();
+
+    // then
+
+    verify(settlementService, times(1)).readSettlementPage(eq(teamId),
+        any(SettlementSearchCondition.class), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("정산 목록 조회 API - 정렬 파라미터 테스트")
+  void readSettlements_WithSortParameter_ShouldReturnSortedPage() throws Exception {
+    // given
+    Long teamId = 1L;
+    SettlementResponse settlement1 = SettlementResponse.builder()
+        .id(1L)
+        .amount(BigDecimal.valueOf(2000))
+        .build();
+
+    SettlementResponse settlement2 = SettlementResponse.builder()
+        .id(2L)
+        .amount(BigDecimal.valueOf(1000))
+        .build();
+
+    // 금액 내림차순 정렬 결과 (2000원이 먼저 나옴)
+    List<SettlementResponse> settlements = List.of(settlement1, settlement2);
+    Page<SettlementResponse> mockPage = new PageImpl<>(settlements, PageRequest.of(0, 10), 2);
+
+    when(settlementService.readSettlementPage(eq(teamId), any(SettlementSearchCondition.class),
+        any(Pageable.class)))
+        .thenReturn(mockPage);
+
+    // when
+    MvcResult result = mockMvc.perform(get("/api/teams/{teamId}/settlements", teamId)
+            .param("sort", "amount,desc")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // then
+    String content = result.getResponse().getContentAsString();
+
+    // ID 순서로 확인 (정렬된 결과대로 나오는지)
+    int firstIdIndex = content.indexOf("\"id\":1");
+    int secondIdIndex = content.indexOf("\"id\":2");
+    assertThat(firstIdIndex).isLessThan(secondIdIndex);
+
+    verify(settlementService, times(1)).readSettlementPage(eq(teamId),
+        any(SettlementSearchCondition.class), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("정산 수정 API 테스트")
+  void updateSettlement_ShouldUpdateAndReturnSettlement() throws Exception {
+    // given
+    Long settlementId = 1L;
+    SettlementUpdateRequest request = new SettlementUpdateRequest();
+    request.setAmount(BigDecimal.valueOf(2000));
+    request.setPayerId(20L);
+    request.setSettlerId(10L);
+    request.setExpenseId(30L);
+    request.setIsSettled(false);
+
+    SettlementResponse mockResponse = SettlementResponse.builder()
+        .id(settlementId)
+        .amount(BigDecimal.valueOf(2000))
+        .settlerId(10L)
+        .payerId(20L)
+        .expenseId(30L)
+        .isSettled(false)
+        .build();
+
+    when(settlementService.updateSettlement(eq(settlementId), any(SettlementUpdateRequest.class)))
+        .thenReturn(mockResponse);
+
+    // when
+    MvcResult result = mockMvc.perform(patch("/api/settlements/{settlementId}", settlementId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // then
+    String content = result.getResponse().getContentAsString();
+    SettlementResponse response = objectMapper.readValue(content, SettlementResponse.class);
+
+    assertThat(response.getId()).isEqualTo(settlementId);
+    assertThat(response.getAmount()).isEqualTo(BigDecimal.valueOf(2000));
+    assertThat(response.getSettlerId()).isEqualTo(10L);
+    assertThat(response.getPayerId()).isEqualTo(20L);
+    assertThat(response.getExpenseId()).isEqualTo(30L);
+    assertThat(response.getIsSettled()).isFalse();
+
+    verify(settlementService, times(1)).updateSettlement(eq(settlementId),
+        any(SettlementUpdateRequest.class));
+  }
+
+  @Test
+  @DisplayName("정산 완료 처리 API 테스트")
+  void settleSettlement_ShouldMarkAsSettled() throws Exception {
+    // given
+    Long settlementId = 1L;
+    SettlementUpdateRequest request = new SettlementUpdateRequest();
+
+    SettlementResponse mockResponse = SettlementResponse.builder()
+        .id(settlementId)
+        .amount(BigDecimal.valueOf(1000))
+        .settlerId(10L)
+        .payerId(20L)
+        .expenseId(30L)
+        .isSettled(true)
+        .build();
+
+    when(settlementService.settleSettlement(settlementId)).thenReturn(mockResponse);
+
+    // when
+    MvcResult result = mockMvc.perform(patch("/api/settlements/{settlementId}", settlementId)
+            .param("settledOnly", "true")  // settledOnly=true 파라미터 추가
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // then
+    String content = result.getResponse().getContentAsString();
+    SettlementResponse response = objectMapper.readValue(content, SettlementResponse.class);
+
+    assertThat(response.getId()).isEqualTo(settlementId);
+    assertThat(response.getIsSettled()).isTrue(); // 정산 완료됨 확인
+
+    verify(settlementService, times(1)).settleSettlement(settlementId);
+    verify(settlementService, times(0)).updateSettlement(anyLong(),
+        any()); // updateSettlement는 호출되지 않음
+  }
+}

--- a/Backend/src/test/java/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.java
@@ -1,0 +1,172 @@
+package com.luckyseven.backend.domain.settlements.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.luckyseven.backend.domain.settlements.TempExpense;
+import com.luckyseven.backend.domain.settlements.TempMember;
+import com.luckyseven.backend.domain.settlements.TempTeam;
+import com.luckyseven.backend.domain.settlements.dao.SettlementRepository;
+import com.luckyseven.backend.domain.settlements.dto.SettlementCreateRequest;
+import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
+import com.luckyseven.backend.domain.settlements.dto.SettlementSearchCondition;
+import com.luckyseven.backend.domain.settlements.dto.SettlementUpdateRequest;
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementServiceTest {
+
+  @Mock
+  private SettlementRepository settlementRepository;
+
+  @InjectMocks
+  private SettlementService settlementService;
+
+  private TempTeam team;
+  private Settlement settlement;
+  private TempMember settler;
+  private TempMember payer;
+  private TempExpense expense;
+
+  @BeforeEach
+  void setUp() {
+    team = new TempTeam();
+    settler = new TempMember(team);
+    payer = new TempMember(team);
+    expense = new TempExpense(team);
+    settlement = Settlement.builder()
+        .amount(BigDecimal.valueOf(1000))
+        .settler(settler)
+        .payer(payer)
+        .expense(expense)
+        .build();
+  }
+
+  @Test
+  @DisplayName("정산생성")
+  void createSettlement_ShouldSaveSettlement() {
+    //given
+    when(settlementRepository.save(any(Settlement.class))).thenReturn(settlement);
+    SettlementCreateRequest request = new SettlementCreateRequest();
+    request.setAmount(BigDecimal.valueOf(1000));
+    request.setPayerId(payer.getId());
+    request.setSettlerId(settler.getId());
+    request.setExpenseId(expense.getId());
+
+    //when
+    SettlementResponse created = settlementService.createSettlement(request);
+
+    //then
+    assertNotNull(created);
+    assertThat(created.getAmount()).isEqualTo(BigDecimal.valueOf(1000));
+    assertThat(created.getSettlerId()).isEqualTo(settler.getId());
+    assertThat(created.getPayerId()).isEqualTo(payer.getId());
+    assertThat(created.getExpenseId()).isEqualTo(expense.getId());
+    assertFalse(created.getIsSettled());
+  }
+
+  @Test
+  @DisplayName("정산롼료")
+  void setSettled_ShouldUpdateSettlementStatus() {
+    //given
+    when(settlementRepository.findById(anyLong())).thenReturn(Optional.of(settlement));
+    when(settlementRepository.save(any(Settlement.class))).thenReturn(settlement);
+
+    SettlementResponse updated = settlementService.settleSettlement(1L);
+
+    assertTrue(updated.getIsSettled());
+    verify(settlementRepository).save(settlement);
+  }
+
+  @Test
+  @DisplayName("정산 조회")
+  void findSettlement_ShouldReturnSettlement() {
+    //given
+    when(settlementRepository.findById(anyLong())).thenReturn(Optional.of(settlement));
+
+    //when
+    SettlementResponse found = settlementService.readSettlement(1L);
+
+    //then
+    assertNotNull(found);
+    assertThat(found.getAmount()).isEqualTo(BigDecimal.valueOf(1000));
+    assertThat(found.getSettlerId()).isEqualTo(settler.getId());
+    assertThat(found.getPayerId()).isEqualTo(payer.getId());
+    assertThat(found.getExpenseId()).isEqualTo(expense.getId());
+  }
+
+  @Test
+  @DisplayName("정산 수정")
+  void updateSettlement_ShouldUpdateSettlement() {
+    //given
+    when(settlementRepository.findById(anyLong())).thenReturn(Optional.of(settlement));
+    when(settlementRepository.save(any(Settlement.class))).thenReturn(settlement);
+
+    BigDecimal newAmount = BigDecimal.valueOf(2000);
+    SettlementUpdateRequest request = new SettlementUpdateRequest();
+    request.setAmount(newAmount);
+    request.setPayerId(payer.getId());
+    request.setSettlerId(settler.getId());
+    request.setExpenseId(expense.getId());
+
+    //when
+    SettlementResponse updated = settlementService.updateSettlement(1L, request);
+
+    //then
+    assertNotNull(updated);
+    assertThat(updated.getAmount()).isEqualTo(newAmount);
+    assertThat(updated.getSettlerId()).isEqualTo(settler.getId());
+    assertThat(updated.getPayerId()).isEqualTo(payer.getId());
+    assertThat(updated.getExpenseId()).isEqualTo(expense.getId());
+  }
+
+  @Test
+  @DisplayName("정산목록조회_페이지네이션_명세")
+  void findAllSettlements_ShouldReturnAllSettlements() {
+    //given
+    List<Settlement> settlements = new ArrayList<>();
+    settlements.add(settlement);
+    Page<Settlement> mockPage = new PageImpl<>(settlements);
+    when(settlementRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(mockPage);
+
+    SettlementSearchCondition condition = new SettlementSearchCondition();
+    condition.setPayerId(1L);
+    condition.setSettlerId(1L);
+    condition.setExpenseId(1L);
+    condition.setIsSettled(false);
+
+    //when
+    Page<SettlementResponse> result = settlementService.readSettlementPage(1L, condition,
+        PageRequest.of(0, 10));
+
+    //then
+    assertThat(result.getContent().size()).isEqualTo(1);
+    assertThat(result.getContent()).allMatch(s -> s.getAmount().equals(BigDecimal.valueOf(1000)));
+    assertThat(result.getContent()).allMatch(s -> !s.getIsSettled());
+    verify(settlementRepository).findAll(any(Specification.class), any(Pageable.class));
+  }
+
+}

--- a/Backend/src/test/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepositoryTest.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/settlements/dao/SettlementRepositoryTest.java
@@ -1,0 +1,169 @@
+package com.luckyseven.backend.domain.settlements.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.luckyseven.backend.domain.settlements.TempExpense;
+import com.luckyseven.backend.domain.settlements.TempMember;
+import com.luckyseven.backend.domain.settlements.TempTeam;
+import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class SettlementRepositoryTest {
+
+  @Autowired
+  private SettlementRepository settlementRepository;
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  TempTeam team1;
+  TempTeam team2;
+  TempMember settler1;
+  TempMember settler2;
+  TempMember payer1;
+  TempMember payer2;
+  TempExpense expense1;
+  TempExpense expense2;
+
+  @BeforeEach
+  void setUp() {
+    team1 = new TempTeam();
+    team2 = new TempTeam();
+
+    // 먼저 팀 엔티티 저장
+    entityManager.persist(team1);
+    entityManager.persist(team2);
+
+    settler1 = new TempMember(team1);
+    settler2 = new TempMember(team2);
+    payer1 = new TempMember(team1);
+    payer2 = new TempMember(team2);
+
+    // 멤버 엔티티 저장
+    entityManager.persist(settler1);
+    entityManager.persist(settler2);
+    entityManager.persist(payer1);
+    entityManager.persist(payer2);
+
+    expense1 = new TempExpense(team1);
+    expense2 = new TempExpense(team2);
+
+    // 비용 엔티티 저장
+    entityManager.persist(expense1);
+    entityManager.persist(expense2);
+
+    // 변경사항 반영
+    entityManager.flush();
+
+    for (int i = 0; i < 20; i++) {
+      Settlement settlement = Settlement.builder()
+          .amount(BigDecimal.valueOf(1000))
+          .settler(i < 5 ? settler1 : settler2)
+          .payer(i < 10 ? payer1 : payer2)
+          .expense(i < 15 ? expense1 : expense2)
+          .build();
+      if (i % 2 == 0) {
+        settlement.setSettled();
+      }
+      settlementRepository.save(settlement);
+    }
+  }
+
+  @Test
+  @DisplayName("팀_명세")
+  void findAllWithTeamSpecification() {
+    // given
+    Specification<Settlement> team1Spec = Specification.where(
+        SettlementSpecification.hasTeamId(team1.getId()));
+    PageRequest pageRequest = PageRequest.of(0, 10);
+
+    // when
+    Page<Settlement> result = settlementRepository.findAll(team1Spec, pageRequest);
+
+    // then
+    assertThat(result.getContent()).hasSize(10);
+    assertThat(result.getTotalElements()).isEqualTo(15);
+    assertThat(result.getContent()).allMatch(s -> s.getExpense().getTeam().equals(team1));
+  }
+
+  @Test
+  @DisplayName("정산_명세")
+  void findAllWithExpenseSpecification() {
+    // given
+    Specification<Settlement> team1Spec = Specification.where(
+        SettlementSpecification.hasExpenseId(expense1.getId()));
+    PageRequest pageRequest = PageRequest.of(0, 10);
+
+    // when
+    Page<Settlement> result = settlementRepository.findAll(team1Spec, pageRequest);
+
+    // then
+    assertThat(result.getContent()).hasSize(10);
+    assertThat(result.getTotalElements()).isEqualTo(15);
+    assertThat(result.getContent()).allMatch(s -> s.getExpense().equals(expense1));
+  }
+
+  @Test
+  @DisplayName("정산완료여부_명세")
+  void findAllWithSettledSpecification() {
+    // given
+    Specification<Settlement> settledSpec = Specification.where(
+        SettlementSpecification.isSettled(true));
+    PageRequest pageRequest = PageRequest.of(0, 10);
+
+    // when
+    Page<Settlement> result = settlementRepository.findAll(settledSpec, pageRequest);
+
+    // then
+    assertThat(result.getContent()).hasSize(10);
+    assertThat(result.getTotalElements()).isEqualTo(10);
+    assertThat(result.getContent()).allMatch(Settlement::getIsSettled);
+  }
+
+  @Test
+  @DisplayName("지불자_명세")
+  void findAllWithPayerSpecification() {
+    // given
+    Specification<Settlement> payerSpec = Specification.where(
+        SettlementSpecification.hasPayerId(payer1.getId()));
+    PageRequest pageRequest = PageRequest.of(0, 10);
+
+    // when
+    Page<Settlement> result = settlementRepository.findAll(payerSpec, pageRequest);
+
+    // then
+    assertThat(result.getContent()).hasSize(10);
+    assertThat(result.getTotalElements()).isEqualTo(10);
+    assertThat(result.getContent()).allMatch(s -> s.getPayer().equals(payer1));
+  }
+
+  @Test
+  @DisplayName("정산자_명세")
+  void findAllWithSettlerSpecification() {
+    // given
+    Specification<Settlement> payerSpec = Specification.where(
+        SettlementSpecification.hasSettlerId(settler1.getId()));
+    PageRequest pageRequest = PageRequest.of(0, 10);
+
+    // when
+    Page<Settlement> result = settlementRepository.findAll(payerSpec, pageRequest);
+
+    // then
+    assertThat(result.getContent()).hasSize(5);
+    assertThat(result.getTotalElements()).isEqualTo(5);
+    assertThat(result.getContent()).allMatch(s -> s.getSettler().equals(settler1));
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- Closes: #2 

## 📝작업 내용
- 정산 엔티티
- 컨트롤러
- 서비스
- 리포지토리
- 매퍼
- DTO

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함 
- [x] 테스트를 수행함

## 💬리뷰 요구사항
- 정산 목록 조회에 Specification이랑 Pagination 적용했습니다. 팀ID는 Path Variable이라 필수로 받도록 했습니다.
검색 파라미터가 너무 많아져서 DTO 이용해서 ModelAttribute로 받아옵니다.