### PR TITLE
refactor: 정산 메서드 호출 및 리팩토링 

### DIFF
--- a/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
@@ -51,6 +51,7 @@ public class ExpenseService {
     Expense expense = ExpenseMapper.fromExpenseRequest(request, team, payer);
     Expense saved = expenseRepository.save(expense);
 
+    // TODO: 낙관적 락(Lock) 적용 검토
     budget.updateBalance(budget.getBalance().subtract(request.amount()));
 
     createAllSettlements(request, payer, saved);

--- a/Backend/src/main/java/com/luckyseven/backend/domain/member/service/MemberService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/member/service/MemberService.java
@@ -14,6 +14,8 @@ import com.luckyseven.backend.sharedkernel.jwt.utill.JwtTokenizer;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
+import java.util.HashSet;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -96,4 +98,11 @@ public class MemberService {
     );
   }
 
+  public List<Member> findMembersByIds(List<Long> ids) {
+    List<Member> members = memberRepository.findAllById(ids);
+    if (members.size() != new HashSet<>(ids).size()) {
+      throw new CustomLogicException(ExceptionCode.MEMBER_ID_NOTFOUND);
+    }
+    return members;
+  }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/app/SettlementService.java
@@ -1,7 +1,6 @@
 package com.luckyseven.backend.domain.settlements.app;
 
-import static com.luckyseven.backend.sharedkernel.exception.ExceptionCode.EXPENSE_NOT_FOUND;
-
+import com.luckyseven.backend.domain.expense.dto.ExpenseRequest;
 import com.luckyseven.backend.domain.expense.entity.Expense;
 import com.luckyseven.backend.domain.expense.repository.ExpenseRepository;
 import com.luckyseven.backend.domain.member.entity.Member;
@@ -16,6 +15,12 @@ import com.luckyseven.backend.domain.settlements.entity.Settlement;
 import com.luckyseven.backend.domain.settlements.util.SettlementMapper;
 import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
 import com.luckyseven.backend.sharedkernel.exception.ExceptionCode;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,14 +36,58 @@ public class SettlementService {
   private final MemberService memberService;
   private final ExpenseRepository expenseRepository;
 
-  @Transactional
-  public SettlementResponse createSettlement(SettlementCreateRequest request,
-      Member payer, Expense expense) {
+  public void createAllSettlements(ExpenseRequest request, Member payer, Expense expense) {
+    List<Long> settlerIds = request.settlerId();
+    List<Long> nonPayerIds = getNonPayerIds(settlerIds, request.payerId());
 
-    Member settler = memberService.findMemberOrThrow(request.settlerId());
-    Settlement settlement = SettlementMapper.fromSettlementCreateRequest(request, settler, payer,
-        expense);
-    return SettlementMapper.toSettlementResponse(settlementRepository.save(settlement));
+    BigDecimal shareAmount = calculateShareAmount(request.amount(), settlerIds.size());
+
+    Map<Long, Member> settlerMap = getSettlerMap(nonPayerIds);
+
+    List<Settlement> settlements = nonPayerIds.stream()
+        .map(settlerId -> createSettlement(settlerId, payer, expense, shareAmount, settlerMap))
+        .toList();
+
+    settlementRepository.saveAll(settlements);
+  }
+
+  private List<Long> getNonPayerIds(List<Long> settlerIds, Long payerId) {
+    return settlerIds.stream()
+        .filter(id -> !id.equals(payerId))
+        .toList();
+  }
+
+  private BigDecimal calculateShareAmount(BigDecimal amount, int totalMembers) {
+    return amount.divide(BigDecimal.valueOf(totalMembers), RoundingMode.HALF_UP);
+  }
+
+  private Map<Long, Member> getSettlerMap(List<Long> nonPayerIds) {
+    List<Member> settlers = memberService.findMembersByIds(nonPayerIds);
+    return settlers.stream()
+        .collect(Collectors.toMap(Member::getId, Function.identity()));
+  }
+
+  private Settlement createSettlement(Long settlerId, Member payer, Expense expense,
+      BigDecimal shareAmount, Map<Long, Member> settlerMap) {
+    Member settler = settlerMap.get(settlerId);
+    validateSettler(settler);
+
+    SettlementCreateRequest createRequest = SettlementMapper.toSettlementCreateRequest(
+        expense, payer.getId(), settlerId, shareAmount
+    );
+
+    return SettlementMapper.fromSettlementCreateRequest(
+        createRequest,
+        settler,
+        payer,
+        expense
+    );
+  }
+
+  private void validateSettler(Member settler) {
+    if (settler == null) {
+      throw new CustomLogicException(ExceptionCode.NOT_TEAM_MEMBER);
+    }
   }
 
   @Transactional(readOnly = true)
@@ -74,10 +123,15 @@ public class SettlementService {
         memberService.findMemberOrThrow(request.settlerId()) : null;
     Member payer = request.settlerId() != null ?
         memberService.findMemberOrThrow(request.payerId()) : null;
-    Expense expense = findExpenseOrThrow(request.expenseId());
+    Expense expense = getExpense(request);
 
     settlement.update(request.amount(), settler, payer, expense, request.isSettled());
     return SettlementMapper.toSettlementResponse(settlementRepository.save(settlement));
+  }
+
+  private Expense getExpense(SettlementUpdateRequest request) {
+    return expenseRepository.findById(request.expenseId())
+        .orElseThrow(() -> new CustomLogicException(ExceptionCode.EXPENSE_NOT_FOUND));
   }
 
   @Transactional
@@ -92,10 +146,5 @@ public class SettlementService {
         () -> new CustomLogicException(ExceptionCode.SETTLEMENT_NOT_FOUND)
     );
     return settlement;
-  }
-
-  private Expense findExpenseOrThrow(Long expenseId) {
-    return expenseRepository.findById(expenseId)
-        .orElseThrow(() -> new CustomLogicException(EXPENSE_NOT_FOUND));
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/settlements/util/SettlementMapper.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/settlements/util/SettlementMapper.java
@@ -5,6 +5,7 @@ import com.luckyseven.backend.domain.member.entity.Member;
 import com.luckyseven.backend.domain.settlements.dto.SettlementCreateRequest;
 import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
 import com.luckyseven.backend.domain.settlements.entity.Settlement;
+import java.math.BigDecimal;
 
 public class SettlementMapper {
 
@@ -27,5 +28,19 @@ public class SettlementMapper {
   public static Settlement fromSettlementCreateRequest(SettlementCreateRequest request,
       Member settler, Member payer, Expense expense) {
     return new Settlement(request.amount(), settler, payer, expense);
+  }
+
+  public static SettlementCreateRequest toSettlementCreateRequest(
+      Expense expense,
+      Long payerId,
+      Long settlerId,
+      BigDecimal shareAmount
+  ) {
+    return SettlementCreateRequest.builder()
+        .expenseId(expense.getId())
+        .payerId(payerId)
+        .settlerId(settlerId)
+        .amount(shareAmount)
+        .build();
   }
 }

--- a/Backend/src/test/java/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.luckyseven.backend.domain.expense.entity.Expense;
 import com.luckyseven.backend.domain.member.entity.Member;
+import com.luckyseven.backend.domain.member.service.MemberService;
 import com.luckyseven.backend.domain.settlements.dao.SettlementRepository;
 import com.luckyseven.backend.domain.settlements.dto.SettlementCreateRequest;
 import com.luckyseven.backend.domain.settlements.dto.SettlementResponse;
@@ -43,6 +44,9 @@ class SettlementServiceTest {
 
   @Mock
   private SettlementRepository settlementRepository;
+
+  @Mock
+  private MemberService memberService;
 
   @InjectMocks
   private SettlementService settlementService;


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
* #41 
## 📝작업 내용

### 정산 호출 로직 작성

```java
@Transactional
public CreateExpenseResponse saveExpense(Long teamId, ExpenseRequest request) {

    Team team = findTeamWithBudgetOrThrow(teamId);

    Member payer = findPayerOrThrow(request.payerId());

    Budget budget = team.getBudget();
    validateSufficientBudget(request.amount(), budget.getBalance());

    Expense expense = ExpenseMapper.fromExpenseRequest(request, team, payer);
    Expense saved = expenseRepository.save(expense);

    // TODO: 낙관적 락(Lock) 적용 검토
    budget.updateBalance(budget.getBalance().subtract(request.amount()));

    createAllSettlements(request, payer, saved);

    return ExpenseMapper.toCreateExpenseResponse(saved, budget);
}

private void createAllSettlements(ExpenseRequest request, Member payer, Expense expense) {
    settlementService.createAllSettlements(request, payer, expense);
}
```
- `SettlementService` 수정

###  기존의 하나의 지출 -> 정산 책임자 여러명일 때 매번 호출 하는 방식 삭제

* 하나의 지출에 정산 책임자가 여러 명일 경우, 기존에는 각 책임자마다 member를 매번 조회
→ 같은 쿼리가 반복되어 실행됨

* `StopWatch`로 측정해보니, 정산 저장 과정에서 응답 시간이 길어지는 구간이 해당 반복 조회 부분이었음
→ 책임자 3명일 때 약 14ms 소요

* 사용자가 많아지면 커넥션 풀이 일시적으로 부족해져서 병목 현상 발생

```
가상 사용자 100명

평균 응답 시간: 199ms, 최대 1.88초
```



<img width="1457" alt="지출 등록" src="https://github.com/user-attachments/assets/4c0a5fc8-ea0b-49e3-b1b8-1de62254ef88" />

![image](https://github.com/user-attachments/assets/2529238b-da8d-44bd-8f52-8d7e7fb55022)


* 지출 내역 -> 정산 책임자 한번에 끌고 와서 저장
-> memberRepository.findAllById(settlerIds)를 통해 필요한 멤버를 일괄 조회
-> 중복 쿼리 제거로 전체 수행 시간 절반 이하로 단축 (13ms → 7ms)
-> `saveAll()` 처리
```java
public void createAllSettlements(ExpenseRequest request, Member payer, Expense expense) {
    List<Long> settlerIds = request.settlerId();
    List<Long> nonPayerIds = getNonPayerIds(settlerIds, request.payerId());

    BigDecimal shareAmount = calculateShareAmount(request.amount(), settlerIds.size());

    Map<Long, Member> settlerMap = getSettlerMap(nonPayerIds);

    List<Settlement> settlements = nonPayerIds.stream()
        .map(settlerId -> createSettlement(settlerId, payer, expense, shareAmount, settlerMap))
        .toList();

    settlementRepository.saveAll(settlements);
}
```

* 순환 참조 문제 해결
-> 기존에는 `ExpenseService`에서 정산 생성 로직을 호출하고, `SettlementService`에서도 `ExpenseService`를 참조하면서 순환 참조 발생
-> 이를 해결하기 위해 `SettlementService`에서는 `ExpenseService` 대신 `ExpenseRepository` 직접 사용하여 `Expense`를 조회하도록 변경

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항
- 위에서 설명한대로 순환 참조 문제가 발생해서 `ExpenseRepository`를 사용하게 했는데 `필온님` 큰 문제가 있을까요?
- `필온님`이 작성하신 지출 등록 메서드를 삭제하고 한번에 정산을 저장하는 로직으로 구현했는데 큰 문제가 발생할까요?
- 워낙 지출 등록하는 부분에서 DB 사용량이 많아서 성능을 개선하고 측정하는게 무척 어렵고 복잡하네요...