### PR TITLE
refactor: 지출 도메인 리팩토링

### DIFF
--- a/Backend/build.gradle
+++ b/Backend/build.gradle
@@ -44,6 +44,12 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+//    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+//    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 }
 
 tasks.named('test') {

--- a/Backend/build.gradle
+++ b/Backend/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
     compileOnly 'org.projectlombok:lombok'
 //    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/Backend/src/main/java/com/luckyseven/backend/BackendApplication.java
+++ b/Backend/src/main/java/com/luckyseven/backend/BackendApplication.java
@@ -2,10 +2,12 @@ package com.luckyseven.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class BackendApplication {
 
   public static void main(String[] args) {

--- a/Backend/src/main/java/com/luckyseven/backend/core/CacheConfig.java
+++ b/Backend/src/main/java/com/luckyseven/backend/core/CacheConfig.java
@@ -1,0 +1,26 @@
+package com.luckyseven.backend.core;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+  @Bean
+  public CacheManager cacheManager() {
+    CaffeineCacheManager cm = new CaffeineCacheManager("recentExpenses");
+    cm.setCaffeine(
+        Caffeine.newBuilder()
+            .maximumSize(10_000)       // 최대 엔트리 수
+            .expireAfterWrite(5, TimeUnit.MINUTES) // TTL
+            .recordStats()
+    );
+    return cm;
+  }
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/budget/entity/Budget.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/budget/entity/Budget.java
@@ -1,7 +1,10 @@
 package com.luckyseven.backend.domain.budget.entity;
 
+import static com.luckyseven.backend.sharedkernel.exception.ExceptionCode.INSUFFICIENT_BALANCE;
+
 import com.luckyseven.backend.domain.team.entity.Team;
 import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
+import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -131,9 +134,21 @@ public class Budget extends BaseEntity {
 
     return this;
   }
-  public void updateBalance(BigDecimal balance) {
-    if (balance != null) {
-      this.balance = balance;
+
+  public void debit(BigDecimal amount) {
+    if (amount == null) {
+      throw new CustomLogicException(INSUFFICIENT_BALANCE);
     }
+    if (balance.compareTo(amount) < 0) {
+      throw new CustomLogicException(INSUFFICIENT_BALANCE);
+    }
+    this.balance = this.balance.subtract(amount);
+  }
+
+  public void credit(BigDecimal amount) {
+    if (amount == null) {
+      return;
+    }
+    this.balance = this.balance.add(amount);
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/budget/entity/Budget.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/budget/entity/Budget.java
@@ -168,4 +168,5 @@ public class Budget extends BaseEntity {
       throw new CustomLogicException(INSUFFICIENT_BALANCE);
     }
   }
+
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/expense/mapper/ExpenseMapper.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/expense/mapper/ExpenseMapper.java
@@ -61,8 +61,7 @@ public class ExpenseMapper {
         .build();
   }
 
-  public static PageResponse<ExpenseResponse> toPageResponse(Page<Expense> expensePage) {
-    Page<ExpenseResponse> responsePage = expensePage.map(ExpenseMapper::toExpenseResponse);
-    return PageResponse.fromPage(responsePage);
+  public static PageResponse<ExpenseResponse> toPageResponse(Page<ExpenseResponse> page) {
+    return PageResponse.fromPage(page);
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/domain/expense/repository/ExpenseRepository.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/expense/repository/ExpenseRepository.java
@@ -14,6 +14,7 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
   @EntityGraph(attributePaths = {"payer"})
   Page<Expense> findByTeamId(Long teamId, Pageable pageable);
 
+  // TODO: 쿼리 최적화
   @EntityGraph(attributePaths = "payer")
   @Query(
       value = """

--- a/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/CacheEvictService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/CacheEvictService.java
@@ -1,0 +1,26 @@
+package com.luckyseven.backend.domain.expense.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CacheEvictService {
+
+  private final CacheManager cacheManager;
+
+  public void evictByPrefix(String cacheName, String prefix) {
+    Cache cache = cacheManager.getCache(cacheName);
+    if (!(cache instanceof CaffeineCache caffeineCache)) {
+      return;
+    }
+    com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = caffeineCache.getNativeCache();
+    nativeCache.asMap().keySet().stream()
+        .map(Object::toString)
+        .filter(key -> key.startsWith(prefix))
+        .forEach(nativeCache::invalidate);
+  }
+}

--- a/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
@@ -17,6 +17,7 @@ import com.luckyseven.backend.domain.member.service.MemberService;
 import com.luckyseven.backend.domain.settlements.app.SettlementService;
 import com.luckyseven.backend.domain.team.entity.Team;
 import com.luckyseven.backend.domain.team.repository.TeamRepository;
+import com.luckyseven.backend.sharedkernel.cache.CacheEvictService;
 import com.luckyseven.backend.sharedkernel.dto.PageResponse;
 import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
 import java.math.BigDecimal;

--- a/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
@@ -86,8 +86,11 @@ public class ExpenseService {
 
     Budget budget = expense.getTeam().getBudget();
     if (delta.compareTo(BigDecimal.ZERO) > 0) {
-      // 지출 금액이 늘어난 경우 늘어난 부분만큼 원화 차감
+      // 금액 증가 시 원화 잔액 차감
       budget.debitKrw(delta);
+    } else if (delta.compareTo(BigDecimal.ZERO) < 0) {
+      // 금액 감소 시 줄어든 만큼 원화 환불
+      budget.creditKrw(delta.abs());
     }
 
     expense.update(request.description(), newAmount, request.category());

--- a/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/expense/service/ExpenseService.java
@@ -42,8 +42,7 @@ public class ExpenseService {
   @Transactional
   @CacheEvict(value = "recentExpenses", allEntries = true)
   public CreateExpenseResponse saveExpense(Long teamId, ExpenseRequest request) {
-    Team team = teamRepository.findTeamWithBudget(teamId)
-        .orElseThrow(() -> new CustomLogicException(TEAM_NOT_FOUND));
+    Team team = findTeamOrThrow(teamId);
 
     Member payer = memberService.findMemberOrThrow(request.payerId());
     Budget budget = team.getBudget();
@@ -67,6 +66,7 @@ public class ExpenseService {
   }
 
   // TODO: 캐시 튜닝 필요
+
   @Transactional(readOnly = true)
   @Cacheable(
       value = "recentExpenses",
@@ -123,5 +123,10 @@ public class ExpenseService {
     if (balance.compareTo(amount) < 0) {
       throw new CustomLogicException(INSUFFICIENT_BALANCE);
     }
+  }
+
+  private Team findTeamOrThrow(Long teamId) {
+    return teamRepository.findTeamWithBudget(teamId)
+        .orElseThrow(() -> new CustomLogicException(TEAM_NOT_FOUND));
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/sharedkernel/cache/CacheEvictService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/sharedkernel/cache/CacheEvictService.java
@@ -1,12 +1,15 @@
 package com.luckyseven.backend.sharedkernel.cache;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class CacheEvictService {
 
@@ -14,13 +17,27 @@ public class CacheEvictService {
 
   public void evictByPrefix(String cacheName, String prefix) {
     Cache cache = cacheManager.getCache(cacheName);
-    if (!(cache instanceof CaffeineCache caffeineCache)) {
+    if (cache == null) {
+      log.warn("캐시 '{}'를 찾을 수 없습니다. 무효화 작업을 건너뜁니다.", cacheName);
       return;
     }
-    com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = caffeineCache.getNativeCache();
-    nativeCache.asMap().keySet().stream()
-        .map(Object::toString)
-        .filter(key -> key.startsWith(prefix))
-        .forEach(nativeCache::invalidate);
+
+    if (cache instanceof CaffeineCache caffeineCache) {
+      com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache =
+          caffeineCache.getNativeCache();
+
+      List<String> keysToRemove = nativeCache.asMap().keySet().stream()
+          .map(Object::toString)
+          .filter(key -> key.startsWith(prefix))
+          .toList();
+      keysToRemove.forEach(nativeCache::invalidate);
+
+      log.info("Caffeine 캐시 '{}'에서 '{}'로 시작하는 {}건 무효화 완료.",
+          cacheName, prefix, keysToRemove.size());
+      return;
+    }
+
+    cache.clear();
+    log.info("Caffeine 외 캐시 구현체라 전체 clear() 호출 – 네임스페이스='{}'", cacheName);
   }
 }

--- a/Backend/src/main/java/com/luckyseven/backend/sharedkernel/cache/CacheEvictService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/sharedkernel/cache/CacheEvictService.java
@@ -1,4 +1,4 @@
-package com.luckyseven.backend.domain.expense.service;
+package com.luckyseven.backend.sharedkernel.cache;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;

--- a/Backend/src/test/java/com/luckyseven/backend/domain/expense/service/ExpenseServiceTest.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/expense/service/ExpenseServiceTest.java
@@ -58,6 +58,9 @@ class ExpenseServiceTest {
 
   @Mock
   private SettlementService settlementService;
+  
+  @Mock
+  private CacheEvictService cacheEvictService;
 
   @Mock
   private SettlementRepository settlementRepository;

--- a/Backend/src/test/java/com/luckyseven/backend/domain/expense/service/ExpenseServiceTest.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/expense/service/ExpenseServiceTest.java
@@ -24,6 +24,7 @@ import com.luckyseven.backend.domain.settlements.app.SettlementService;
 import com.luckyseven.backend.domain.settlements.dao.SettlementRepository;
 import com.luckyseven.backend.domain.team.entity.Team;
 import com.luckyseven.backend.domain.team.repository.TeamRepository;
+import com.luckyseven.backend.sharedkernel.cache.CacheEvictService;
 import com.luckyseven.backend.sharedkernel.dto.PageResponse;
 import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
 import com.luckyseven.backend.sharedkernel.exception.ExceptionCode;
@@ -58,7 +59,7 @@ class ExpenseServiceTest {
 
   @Mock
   private SettlementService settlementService;
-  
+
   @Mock
   private CacheEvictService cacheEvictService;
 

--- a/Backend/src/test/java/com/luckyseven/backend/domain/expense/service/ExpenseServiceTest.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/expense/service/ExpenseServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.luckyseven.backend.domain.budget.entity.Budget;
+import com.luckyseven.backend.domain.budget.entity.CurrencyCode;
 import com.luckyseven.backend.domain.expense.dto.CreateExpenseResponse;
 import com.luckyseven.backend.domain.expense.dto.ExpenseBalanceResponse;
 import com.luckyseven.backend.domain.expense.dto.ExpenseRequest;
@@ -79,7 +80,9 @@ class ExpenseServiceTest {
   void setUp() {
     budget = Budget.builder()
         .balance(new BigDecimal("100000.00"))
-        .foreignBalance(new BigDecimal("50.00"))
+        .foreignBalance(new BigDecimal("100000.00"))
+        .foreignCurrency(CurrencyCode.USD)
+        .avgExchangeRate(new BigDecimal("1.00"))
         .build();
     payer = Member.builder()
         .email("dldldldl@naver.com")
@@ -124,7 +127,7 @@ class ExpenseServiceTest {
           .payerId(1L)
           .settlerId(List.of(10L, 20L))
           .description("럭키비키즈 점심 식사")
-          .amount(new BigDecimal("50000.00"))
+          .amount(new BigDecimal("10000.00"))
           .category(ExpenseCategory.MEAL)
           .paymentMethod(PaymentMethod.CASH)
           .build();


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #50 

## 📝작업 내용

### 1. 지출 내역 리스트 조회 시 문제점 파악

```
Virtual Users (VU): 최대 50명  
RPS(Requests/sec): 평균 732, 최대 1,360  
응답 시간 (http_req_duration):
  - 평균: 55.9 ms  
  - p90: 168.7 ms  
  - p95: 214.2 ms  
  - 최대: 630.8 ms  
```

* DB 직접 조회로 인한 응답 지연
* 모든 요청마다 RDB를 조회하면서 평균 응답시간 55ms, p95 기준 최대 214ms까지 증가

![캐시처리 X](https://github.com/user-attachments/assets/e98f996c-5516-419a-be6c-cbf9d8c90e92)

* DB 커넥션 부족 현상 발생
 -> `HikariCP 커넥션 풀의 기본 설정(10개)을 초과해 최대 37개 요청이 대기`
 -> 캐시가 있었다면 대기 없이 응답 가능했을 부분에서 병목 발생
* 비효율적인 쿼리 구성
 -> `LEFT JOIN`,  `페이징` 등으로 쿼리 자체의 비용도 높음

![캐시 처리 X 디비 부하](https://github.com/user-attachments/assets/31a01f0a-94ee-4eb7-ad95-9adadf23d72d)


### 2. 개선


* 불필요한 JOIN 제거
  * LEFT JOIN team 삭제 → expense.team_id 로 바로 필터링
* DTO 프로젝션
  * 필요한 컬럼만 조회 
* 페이징용 카운트 쿼리 분리
* 캐시 적용
```java
// 조회: 캐시 적용
@Cacheable(
  value = "recentExpenses",
  key = "'team:' + #teamId + ':page:' + #pageable.pageNumber + ':size:' + #pageable.pageSize"
)
public PageResponse<ExpenseResponse> getListExpense(Long teamId, Pageable pageable) { … }

// 생성·수정·삭제: 캐시 무효화
public CreateExpenseResponse saveExpense(...) {evictRecentExpensesForTeam(teamId)}
public CreateExpenseResponse updateExpense(...) {evictRecentExpensesForTeam(teamId)}
public ExpenseBalanceResponse deleteExpense(...) {evictRecentExpensesForTeam(teamId)}
```

```java
 public void evictByPrefix(String cacheName, String prefix) {
    Cache cache = cacheManager.getCache(cacheName);
    if (cache == null) {
      log.warn("캐시 '{}'를 찾을 수 없습니다. 무효화 작업을 건너뜁니다.", cacheName);
      return;
    }

    if (cache instanceof CaffeineCache caffeineCache) {
      com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache =
          caffeineCache.getNativeCache();

      List<String> keysToRemove = nativeCache.asMap().keySet().stream()
          .map(Object::toString)
          .filter(key -> key.startsWith(prefix))
          .toList();
      keysToRemove.forEach(nativeCache::invalidate);

      log.info("Caffeine 캐시 '{}'에서 '{}'로 시작하는 {}건 무효화 완료.",
          cacheName, prefix, keysToRemove.size());
      return;
    }

    cache.clear();
    log.info("Caffeine 외 캐시 구현체라 전체 clear() 호출 – 네임스페이스='{}'", cacheName);
}
```

* `@CacheEvict`로는 특정 키 하나만 지우거나, allEntries=true로 전체를 날리는 것만 가능
    * Caffeine 네이티브 API 활용: 내부 캐시 맵의 키들을 순회하며, 문자열이 지정한 접두사(prefix) 로 시작하는 항목만 골라 invalidate()
    * Caffeine 네이티브 API로 키 목록을 순회하면서 "team:{teamId}:" 로 시작하는 항목만 골라 한 번에 invalidate하기 때문에 해당 팀의 모든 페이지 캐시만 삭제, 다른 팀 캐시는 그대로 유지 


* 캐시 적용 후 성능 (k6 부하 테스트)

![스크린샷 2025-05-19 오후 4 50 02](https://github.com/user-attachments/assets/d15b08d3-a348-4130-bd9e-c5cd3cbc8341)

```
Virtual Users (VU): 최대 50명  
RPS(Requests/sec): 평균 2,000, 최대 2,840  
응답 시간 (http_req_duration):
  - 평균: 20.0 ms  
  - p90: 60.0 ms  
  - p95: 89.8 ms  
  - 최대: 565.5 ms  
```
### 결과

* 응답 시간 대폭 단축 (평균 55.9→20.0 ms, p95 214.2→89.8 ms)

* RPS 증가 (732→2,000)

* 커넥션 풀 대기 해소 (Pending Threads 감소)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항
* 지출 내역 리스트는 조회가 빈번히 일어나므로 캐시 처리를 해보았는데 어떻게 생각하시나요? 괜찮게 적용된건가요?
* 예산 수정을 할 때 낙관적 락을 걸려고 했는데 우선 동시성 문제가 발생하는지 테스트 후 -> 개선을 해볼려했는데 아직 개념이 부족해서 시간이  여유가 되면 시도 해봐야할 것 같습니다. -> `Budget`에 락을 걸면 `Team`도 락이 걸려서 골치아파서 조금 봐야할거 같습니다.
* 개선할게 너무 많네요...ㅠㅠ