### PR TITLE
bugfix(budget): 예산 삭제 시 삭제가 안되는 이슈 해결

### DIFF
--- a/Backend/src/main/java/com/luckyseven/backend/domain/budget/service/BudgetService.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/budget/service/BudgetService.java
@@ -75,7 +75,14 @@ public class BudgetService {
 
   @Transactional
   public void deleteByTeamId(Long teamId) {
+    Team team = teamRepository.findById(teamId)
+        .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다: " + teamId));
+
+
     Budget budget = budgetValidator.validateBudgetExist(teamId);
+
+    team.setBudget(null);
+    teamRepository.save(team);
     budgetRepository.delete(budget);
   }
 

--- a/Frontend/luckeyseven/src/pages/TeamDashBoard.js
+++ b/Frontend/luckeyseven/src/pages/TeamDashBoard.js
@@ -1,11 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {useRecoilValue} from 'recoil';
 import {currentTeamIdState} from '../recoil/atoms/teamAtoms';
-import {getTeamDashboard, getTeamMembers} from '../service/ApiService'
-import React, { useState, useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
-import { currentTeamIdState } from '../recoil/atoms/teamAtoms';
-import { getTeamDashboard, getTeamMembers } from '../service/TeamService';
+import {getTeamDashboard, getTeamMembers} from '../service/TeamService';
 import styles from '../styles/App.module.css';
 import Header from '../components/Header';
 import PageHeaderControls from '../components/PageHeaderControls';


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #이슈 번호

## 📝작업 내용
1. 버그 현상
- 기존 코드에서는 Team과 Budget이 1:1 양방향 연관관계로 매핑되어 있음.
- Team이 Budget을 참조(@OneToOne(cascade = ALL, orphanRemoval = true)),
Budget은 mappedBy로 Team을 참조.
문제: Budget만 직접 삭제할 때 실제 DB에 delete 쿼리가 발생하지 않는다. (select 만 2회 발생)
2. 원인
  - JPA는 Team이 Budget을 계속 참조하는 상태에서는 Budget을 “고아”로 간주하지 않으므로, orphanRemoval 옵션이 있어도 delete 쿼리를 내보내지 않음.
  - 결과적으로 Team에서 Budget 참조를 끊지 않고 Budget만 삭제하려 하면
select 쿼리만 2회 발생하고, delete 쿼리는 발생하지 않는 현상 발생.
3. 해결
  - Budget 삭제 시 반드시 Team에서 Budget 참조를 끊어야 함.
  - Budget을 삭제할 때 
  ```
    `team.setBudget(null);
    teamRepository.save(team)`; 
  ```
  과정을 삭제 전 , orphanRemoval 옵션에 의해 Budget이 실제로 삭제된다.
4. 변경 사항
  ```
    @Transactional
    public void deleteByTeamId(Long teamId) {
      Team team = teamRepository.findById(teamId)
          .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다: " + teamId));
  
  
      Budget budget = budgetValidator.validateBudgetExist(teamId);
  
      team.setBudget(null);
      teamRepository.save(team);
      budgetRepository.delete(budget);
    }
  ```
## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?