### PR TITLE
refactor(*): 통합 로직 테스트 후 리펙토링

### DIFF
--- a/Frontend/luckeyseven/public/index.html
+++ b/Frontend/luckeyseven/public/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="인증 시스템" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>인증 시스템</title>
+    <title>Travel Expense Manage</title>
   </head>
   <body>
     <noscript>이 앱을 실행하려면 JavaScript를 활성화해야 합니다.</noscript>

--- a/Frontend/luckeyseven/src/components/OverviewTabContent.js
+++ b/Frontend/luckeyseven/src/components/OverviewTabContent.js
@@ -1,34 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styles from '../styles/App.module.css';
-import SummaryCard from '../components/SummaryCard';
-import BudgetBreakdown from '../components/BudgetBreakdown';
-import RecentExpensesTable from '../components/RecentExpenseTable';
+import SummaryCard from './SummaryCard';
+import BudgetBreakdown from './BudgetBreakdown';
+import RecentExpensesTable from './RecentExpenseTable';
 
 const OverviewTabContent = ({ dashboardData }) => {
-  // 모든 React Hooks는 컴포넌트의 최상위 레벨에서 호출되어야 함
-  const [savedTotalExpense, setSavedTotalExpense] = useState(0);
+  // 이제 매번 balance로부터 계산할 것이므로 필요 없음
   const initializedRef = useRef(false);
-
-  // useEffect도 최상위 레벨에서 호출
-  useEffect(() => {
-    // dashboardData가 없으면 아무것도 하지 않음
-    if (!dashboardData) return;
-
-    const { expenseList = [] } = dashboardData;
-    
-    // 아직 초기화되지 않았고, expenseList가 있는 경우에만 실행
-    if (!initializedRef.current && expenseList && expenseList.length > 0) {
-      // expenseList에서 총 지출 계산
-      const calculatedExpense = expenseList.reduce((sum, expense) => 
-        sum + parseFloat(expense.amount || 0), 0);
-      
-      // 계산된 값이 0보다 크면 저장
-      if (calculatedExpense > 0) {
-        setSavedTotalExpense(calculatedExpense);
-        initializedRef.current = true;
-      }
-    }
-  }, [dashboardData]); // dashboardData가 변경될 때만 실행
 
   // 조기 반환은 모든 Hooks가 호출된 후에 수행
   if (!dashboardData) {
@@ -36,19 +14,23 @@ const OverviewTabContent = ({ dashboardData }) => {
   }
 
   const {
-    // 사용하지 않는 변수들은 제거하거나 필요하면 유지할 수 있음
     // team_id,
     // teamName,
     totalAmount = 0, // 기본값 설정
-    balance = 0, // 기본값 설정
+    balance = 0, // 기본값 설정, 이제 이 값을 그대로 사용
     foreignBalance = 0, // 기본값 설정
     foreignCurrency = 'KRW', // 기본값 설정
     expenseList = [], // 기본값 설정
     // avgExchangeRate = 0, // 기본값 설정
   } = dashboardData;
 
-  // savedTotalExpense를 사용하여 퍼센티지 계산
-  const totalExpensePercentage = totalAmount > 0 ? (savedTotalExpense / totalAmount) * 100 : 0;
+  // 총 지출을 항상 totalAmount - balance로 계산
+  const totalExpense = totalAmount - balance;
+  
+  // 지출 퍼센티지 계산
+  const totalExpensePercentage = totalAmount > 0 ? (totalExpense / totalAmount) * 100 : 0;
+  
+  // 남은 예산 퍼센티지 계산
   const remainingBudgetPercentage = totalAmount > 0 ? (balance / totalAmount) * 100 : 0;
 
   // 지출 목록이 없는 경우 빈 배열로 처리
@@ -68,7 +50,7 @@ const OverviewTabContent = ({ dashboardData }) => {
     <div>
       <div className={styles.summaryCardContainer}>
         <SummaryCard title="총 예산" amount={totalAmount} currency="₩" />
-        <SummaryCard title="총 지출" amount={savedTotalExpense} currency="₩" percentage={totalExpensePercentage.toFixed(1)} of="of budget" />
+        <SummaryCard title="총 지출" amount={totalExpense} currency="₩" percentage={totalExpensePercentage.toFixed(1)} of="of budget" />
         <SummaryCard title="남은 예산" amount={balance} currency="₩" percentage={remainingBudgetPercentage.toFixed(1)} of="of budget" />
         {foreignCurrency && foreignBalance !== undefined && foreignCurrency !== 'KRW' && (
           <SummaryCard

--- a/Frontend/luckeyseven/src/components/Tabs.js
+++ b/Frontend/luckeyseven/src/components/Tabs.js
@@ -14,9 +14,8 @@ const Tabs = ({ activeTab, setActiveTab }) => {
     switch (tab) {
       case 'Expenses':
         return `/teams/${teamId}/expenses`;
-      case 'Settlement':
-        return '/settlement'
-        // return `/teams/${teamId}/settlements`;
+      // case 'Settlement':
+      //   return `/teams/${teamId}/settlements`;
       default:
         return '#'; // Overview and Members will still use setActiveTab
     }
@@ -24,10 +23,10 @@ const Tabs = ({ activeTab, setActiveTab }) => {
   return (
       <div className={styles.tabs}>
         {tabs.map(tab => {
-          const isLink = tab === 'Expenses' || tab === 'Settlement';
+          // const isLink = tab === 'Expenses' || tab === 'Settlement';
+          const isLink = tab === 'Expenses';
           const path = getTabPath(tab);
-
-          return isLink ? (
+          return (
             <Link
               key={tab}
               to={path}
@@ -36,14 +35,6 @@ const Tabs = ({ activeTab, setActiveTab }) => {
             >
               {tab}
             </Link>
-          ) : (
-            <button
-                key={tab}
-                onClick={() => setActiveTab(tab)}
-                className={`${styles.tabButton} ${activeTab === tab ? styles.tabButtonActive : ''}`}
-            >
-              {tab}
-            </button>
           );
         })}
       </div>

--- a/Frontend/luckeyseven/src/pages/ExpenseDialog/AddExpenseDialog.jsx
+++ b/Frontend/luckeyseven/src/pages/ExpenseDialog/AddExpenseDialog.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { getTeamMembers, createExpense } from '../../service/ExpenseService';
 import '../../components/styles/addExpenseDialog.css';
-
 const CATEGORY_LABELS = {
   MEAL: '식사',
   SNACK: '간식',
@@ -10,16 +9,13 @@ const CATEGORY_LABELS = {
   ACCOMMODATION: '숙박',
   MISCELLANEOUS: '기타',
 };
-
 const PAYMENT_LABELS = {
   CARD: '카드',
   CASH: '현금',
   OTHER: '기타',
 };
-
 const categories = Object.keys(CATEGORY_LABELS);
 const paymentMethods = Object.keys(PAYMENT_LABELS);
-
 export default function AddExpenseDialog({ onClose, onSuccess }) {
   const { teamId } = useParams();
   const [users, setUsers] = useState([]);
@@ -31,7 +27,6 @@ export default function AddExpenseDialog({ onClose, onSuccess }) {
     paymentMethod: paymentMethods[0],
     settlerIds: []
   });
-
   // ESC 키로 닫기
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -42,7 +37,6 @@ export default function AddExpenseDialog({ onClose, onSuccess }) {
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
-
   useEffect(() => {
     async function fetchMembers() {
       try {
@@ -63,7 +57,6 @@ export default function AddExpenseDialog({ onClose, onSuccess }) {
     }
     fetchMembers();
   }, [teamId]);
-
   const handleChange = (e) => {
     const { name, value, options } = e.target;
     if (name === 'settlerIds') {
@@ -79,7 +72,6 @@ export default function AddExpenseDialog({ onClose, onSuccess }) {
       setForm(f => ({ ...f, [name]: value }));
     }
   };
-
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
@@ -92,7 +84,6 @@ export default function AddExpenseDialog({ onClose, onSuccess }) {
         settlerId: form.settlerIds.map(id => Number(id))
       };
       const result = await createExpense(teamId, payload);
-
       if (onSuccess) {
         const newExpense = {
           id: result.id,
@@ -117,7 +108,6 @@ export default function AddExpenseDialog({ onClose, onSuccess }) {
       alert(msg);
     }
   };
-
   return (
     <div className="modal-overlay">
       <div className="modal">
@@ -136,11 +126,11 @@ export default function AddExpenseDialog({ onClose, onSuccess }) {
             />
           </label>
           <label>
-            금액 (₩)
+            금액 (KRW, USD 등)
             <input
               name="amount"
               type="number"
-              step="100"
+              step="0.01"
               value={form.amount}
               onChange={handleChange}
               min="0"

--- a/Frontend/luckeyseven/src/pages/ExpenseDialog/ExpenseDetailDialog.jsx
+++ b/Frontend/luckeyseven/src/pages/ExpenseDialog/ExpenseDetailDialog.jsx
@@ -154,7 +154,7 @@ export default function ExpenseDetailDialog({
                     />
                   </div>
                   <div className="field">
-                    <label>금액 (₩)</label>
+                    <label>금액 (KRW, USD 등)</label>
                     <input
                         type="number"
                         name="amount"
@@ -180,7 +180,7 @@ export default function ExpenseDetailDialog({
                 <>
                   <p><strong>설명</strong> {detail.description}</p>
                   <p><strong>지출 금액</strong> <span
-                      className="amount">{detail.amount.toLocaleString()}원</span>
+                      className="amount">{detail.amount.toLocaleString()}</span>
                   </p>
                   <p><strong>카테고리</strong>{' '}<span className="category"
                                                      data-category={detail.category}>{CATEGORY_LABELS[detail.category]}</span>

--- a/Frontend/luckeyseven/src/pages/ExpenseDialog/ExpenseList.jsx
+++ b/Frontend/luckeyseven/src/pages/ExpenseDialog/ExpenseList.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-
 import AddExpenseDialog from './AddExpenseDialog';
 import ExpenseDetailDialog from './ExpenseDetailDialog';
 import Header from '../../components/Header';
@@ -9,9 +8,7 @@ import { getListExpense } from '../../service/ExpenseService';
 import { currentTeamIdState } from '../../recoil/atoms/teamAtoms';
 import { FaMoneyBillWave } from 'react-icons/fa';
 import { FiHome, FiPlus } from 'react-icons/fi';
-
 import '../../components/styles/expenseList.css';
-
 const CATEGORY_LABELS = {
   MEAL: '식사',
   SNACK: '간식',
@@ -19,11 +16,9 @@ const CATEGORY_LABELS = {
   ACCOMMODATION: '숙박',
   MISCELLANEOUS: '기타',
 };
-
 export default function ExpenseList() {
   const teamId = useRecoilValue(currentTeamIdState);
   const navigate = useNavigate();
-
   const [expenses, setExpenses] = useState([]);
   const [page, setPage] = useState(0);
   const [size] = useState(10);
@@ -31,12 +26,10 @@ export default function ExpenseList() {
   const [sortDirection, setSortDirection] = useState('DESC');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
   const [balances, setBalances] = useState(null);
   const [notification, setNotification] = useState({ message: '', type: '' });
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [selectedExpenseId, setSelectedExpenseId] = useState(null);
-
   const fetchExpenses = useCallback(async () => {
     setLoading(true);
     try {
@@ -50,11 +43,9 @@ export default function ExpenseList() {
       setLoading(false);
     }
   }, [teamId, page, size, sortDirection]);
-
   useEffect(() => {
     fetchExpenses();
   }, [fetchExpenses]);
-
   useEffect(() => {
     if (!balances && !notification.message) return;
     const timer = setTimeout(() => {
@@ -63,7 +54,6 @@ export default function ExpenseList() {
     }, 10000);
     return () => clearTimeout(timer);
   }, [balances, notification]);
-
   const fmt = v => (v != null ? v.toLocaleString() : '-');
   const formatDate = d =>
     new Date(d).toLocaleDateString('ko-KR', {
@@ -72,32 +62,27 @@ export default function ExpenseList() {
       day: 'numeric',
       weekday: 'short',
     });
-
   const openDetail = id => setSelectedExpenseId(id);
   const closeDetail = () => setSelectedExpenseId(null);
   const goToPage = n => setPage(n - 1);
-
   const handleAddSuccess = async (_, bal) => {
     setBalances(bal);
     setNotification({ message: '지출이 성공적으로 등록되었습니다.', type: 'register' });
     setShowAddDialog(false);
     await fetchExpenses();
   };
-
   const handleUpdateSuccess = (updatedExpense, bal) => {
     setExpenses(prev => prev.map(e => (e.id === updatedExpense.id ? updatedExpense : e)));
     setBalances(bal);
     setNotification({ message: '지출이 성공적으로 수정되었습니다.', type: 'update' });
     closeDetail();
   };
-
   const handleDeleteSuccess = (deletedId, bal) => {
     setExpenses(prev => prev.filter(e => e.id !== deletedId));
     setBalances(bal);
     setNotification({ message: '지출이 성공적으로 삭제되었습니다.', type: 'delete' });
     closeDetail();
   };
-
   if (loading) {
     return (
       <div className="expense-tracker">
@@ -108,7 +93,6 @@ export default function ExpenseList() {
       </div>
     );
   }
-
   if (error) {
     return (
       <div className="expense-tracker">
@@ -122,7 +106,6 @@ export default function ExpenseList() {
       </div>
     );
   }
-
   return (
     <div className="expense-tracker">
       <Header />
@@ -130,7 +113,6 @@ export default function ExpenseList() {
         <h2 className="section-title">
           <FaMoneyBillWave className="section-icon" /> 지출 내역
         </h2>
-
         {/* 잔고/알림 배너 */}
         {(balances || notification.message) && (
           <div className="balance-banner">
@@ -149,13 +131,12 @@ export default function ExpenseList() {
             )}
           </div>
         )}
-
         {/* 액션 바 */}
         <div className="actions">
           <div className="header-actions">
-            <button className="btn btn-outlined" onClick={() => navigate('/TeamDashBoard')}>
+            {/* <button className="btn btn-outlined" onClick={() => navigate('/TeamDashBoard')}>
               <FiHome /> 팀 대시보드
-            </button>
+            </button> */}
             <button className="btn btn-filled" onClick={() => setShowAddDialog(true)}>
               <FiPlus /> 지출 추가
             </button>
@@ -169,7 +150,6 @@ export default function ExpenseList() {
             </button>
           </div>
         </div>
-
         {/* 테이블 / 빈 상태 */}
         {expenses.length === 0 ? (
           <div className="empty-state">
@@ -182,7 +162,7 @@ export default function ExpenseList() {
               <thead>
                 <tr>
                   <th>제목</th>
-                  <th>가격 (KRW)</th>
+                  <th>가격 (KRW, USD 등)</th>
                   <th>카테고리</th>
                   <th>날짜</th>
                   <th>결제자</th>
@@ -192,7 +172,7 @@ export default function ExpenseList() {
                 {expenses.map(exp => (
                   <tr key={exp.id} onClick={() => openDetail(exp.id)} style={{ cursor: 'pointer' }}>
                     <td>{exp.description}</td>
-                    <td className="amount">₩{exp.amount.toLocaleString()}</td>
+                    <td className="amount">{exp.amount.toLocaleString()}</td>
                     <td>
                       <span className="category" data-category={exp.category}>
                         {CATEGORY_LABELS[exp.category] || exp.category}
@@ -206,7 +186,6 @@ export default function ExpenseList() {
             </table>
           </div>
         )}
-
         {/* 페이지네이션 */}
         {totalPages > 1 && (
           <div className="pagination">
@@ -232,7 +211,6 @@ export default function ExpenseList() {
             </button>
           </div>
         )}
-
         {/* 다이얼로그 */}
         {showAddDialog && <AddExpenseDialog onClose={() => setShowAddDialog(false)} onSuccess={handleAddSuccess} />}
         {selectedExpenseId && (

--- a/Frontend/luckeyseven/src/pages/TeamDashBoard.js
+++ b/Frontend/luckeyseven/src/pages/TeamDashBoard.js
@@ -8,6 +8,7 @@ import PageHeaderControls from '../components/PageHeaderControls';
 import Tabs from '../components/Tabs';
 import OverviewTabContent from '../components/OverviewTabContent';
 import MembersTabContent from '../components/MembersTabContent';
+import { TeamSettlementsPage } from './Settlement/TeamSettlementsPage';
 import SetBudgetDialog from '../pages/BudgetPage/components/set-budget-dialog';
 import EditBudgetDialog from '../pages/BudgetPage/components/edit-budget-dialog';
 import AddBudgetDialog from '../pages/BudgetPage/components/add-budget-dialog';
@@ -22,7 +23,6 @@ function TeamDashBoard() {
   const [activeTab, setActiveTab] = useState('Overview');
   const teamId = useRecoilValue(currentTeamIdState);
   const [dashboardData, setDashboardData] = useState(null);
-  // Added state for dialog control
   const [dialogType, setDialogType] = useState(null); // 'set', 'edit', 'add', or null
   // 다이얼로그 인스턴스를 구분하기 위한 키 생성 상태 추가
   const [dialogKey, setDialogKey] = useState(Date.now());
@@ -190,8 +190,10 @@ function TeamDashBoard() {
             members={membersData.members}
           />
         )}
+        {activeTab === 'Settlement' && (
+          <TeamSettlementsPage/>
+        )}
 
-        {/* Render dialogs based on dialog type with consistent key */}
         {dialogType === 'set' && (
           <SetBudgetDialog
             key={`set-budget-${dialogKey}`}

--- a/Frontend/luckeyseven/src/router/Router.js
+++ b/Frontend/luckeyseven/src/router/Router.js
@@ -31,7 +31,7 @@ export default function Router() {
         <Route path="/TeamDashBoard" element={<TeamDashBoard/>}/>
         <Route path="/" element={<Home/>}></Route>
         <Route path="/teams/:teamId/expenses" element={<ExpensesPage/>}/>
-        {/*<Route path="/teams/:teamId/settlements" element={<SettlementPage/>}/>*/}
+        {/* <Route path="/teams/:teamId/settlements" element={<SettlementPage/>}/> */}
         <Route path="*" element={<Navigate to="/" replace/>}/>
       </Routes>
   )


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #72 

## 📝작업 내용
- [x] 지출 목록 페이지 대시보드 이동 버튼 중복 제거
- [x] 지출 입력 시 금액 입력 타이틀 수정
- [x] 정산 페이지 연결을 페이지 이동이 아닌 내부에서 열리도록 수정
- [x] 지출 추가 시, 금액을 소수점도 입력 가능하도록 수정(외화 입력 시 필요)
- [x] 페이지 title 인증 시스템 -> Travel Expense Manager로 수정
- [x] 지출 상세 모달에서 금액을 표시할 때 외화도 '원'으로 보이기 때문에 금액 단위 '원' 삭제
- [x] 지출 수정 시 금액 입력 타이틀 수정

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항
- 지출 수정/삭제 후 총 지출, 원화, 외화 업데이트 기능 수정 필요