### PR TITLE
fix: 지출 수정 시 원화 잔고, 외화 잔고 업데이트 문제 해결

### DIFF
--- a/Backend/src/main/java/com/luckyseven/backend/domain/budget/entity/Budget.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/budget/entity/Budget.java
@@ -2,7 +2,6 @@ package com.luckyseven.backend.domain.budget.entity;
 
 import static com.luckyseven.backend.sharedkernel.exception.ExceptionCode.INSUFFICIENT_BALANCE;
 
-import com.luckyseven.backend.domain.budget.dto.BudgetUpdateRequest;
 import com.luckyseven.backend.domain.team.entity.Team;
 import com.luckyseven.backend.sharedkernel.entity.BaseEntity;
 import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
@@ -157,6 +156,18 @@ public class Budget extends BaseEntity {
   public void creditKrw(BigDecimal krwAmount) {
     balance = balance.add(krwAmount);
   }
+
+  public void creditForeign(BigDecimal foreignAmount) {
+    BigDecimal krwAmount = foreignAmount.multiply(avgExchangeRate);
+    this.balance = this.balance.add(krwAmount);
+
+    if (this.foreignBalance == null) {
+      this.foreignBalance = BigDecimal.ZERO;
+    }
+
+    this.foreignBalance = this.foreignBalance.add(foreignAmount);
+  }
+
 
   private void validateSufficientBalance(BigDecimal amount, BigDecimal current) {
     if (current.compareTo(amount) < 0) {


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
* #73 
## 📝작업 내용
- 지출 수정 시 원화 잔고, 외화 잔고 업데이트 문제 해결

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?